### PR TITLE
Burn Menu Icon Click

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -667,7 +667,7 @@ var app = new (function() {
 		self.activeView($(event.target).parent().attr("value"));
 	}	
 	this.setDmgFilter = function(model, event){
-		var dmgType = $(event.target).parent().attr("value");
+		var dmgType = $(event.target).parents('li:first').attr("value");
 		self.dmgFilter.indexOf(dmgType) == -1 ? self.dmgFilter.push(dmgType) : self.dmgFilter.remove(dmgType);
 		//not sure why this happens
 		self.dmgFilter.remove(undefined);


### PR DESCRIPTION
If `setDmgFilter` was triggered by a click on an icon, then `.parent()` is not the `<li>`.

Updated `setDmgFilter` to look for the first ancestor `<li>`.

Closes #6 