### PR TITLE
Add Status Bar configuration via Cordova Plugin

### DIFF
--- a/www/config.xml
+++ b/www/config.xml
@@ -14,7 +14,6 @@
     <preference name="webviewbounce" value="false" />
     <preference name="prerendered-icon" value="true" />
     <preference name="stay-in-webview" value="false" />
-    <preference name="StatusBarStyle" value="lightcontent" />
     <preference name="detect-data-types" value="true" />
     <preference name="exit-on-suspend" value="false" />
     <preference name="show-splash-screen-spinner" value="true" />
@@ -26,6 +25,10 @@
     <gap:plugin name="org.apache.cordova.inappbrowser" version="0.6.0" source="plugins.cordova.io" />
     <gap:plugin name="org.apache.cordova.statusbar" />
     <gap:plugin name="org.apache.cordova.device" version="0.2.3" />
+
+    <preference name="StatusBarOverlaysWebView" value="false"/>
+    <preference name="StatusBarBackgroundColor" value="#000000"/>
+    <preference name="StatusBarStyle" value="lightcontent" />
 
     <icon src="icon.png" />
     <icon gap:platform="android" gap:qualifier="ldpi" src="res/icon/android/icon-36-ldpi.png" />


### PR DESCRIPTION
Configure the Status Bar with plugin options hardcoded. Phonegap will
do the right thing on its own with the values for mobile devices, and
does not involve Javascript or CSS "trickery".

The issue with this change is the background colour is set to black
with no way to make it transparent, or match the background of the
application.

Note, this change may require a new IPA as Phonegap might need it to
handle the config.xml changes.