### PR TITLE
Add ignore armour loadouts for diff classes

### DIFF
--- a/www/js/loadouts.js
+++ b/www/js/loadouts.js
@@ -230,7 +230,8 @@ var Loadout = function(model){
 									}
 								}								
 							}
-							else if ( item.bucketType == "Subclasses" ){							
+							else if ( item.bucketType == "Subclasses"
+							    || ( ["Helmet","Chest","Boots","Gauntlet"].indexOf(item.bucketType) != -1 && item.character.classType != targetCharacter.classType )) {
 								return {
 									description: item.description + " will not be moved"
 								}

--- a/www/js/loadouts.js
+++ b/www/js/loadouts.js
@@ -231,7 +231,7 @@ var Loadout = function(model){
 								}								
 							}
 							else if ( item.bucketType == "Subclasses"
-							    || ( ["Helmet","Chest","Boots","Gauntlet"].indexOf(item.bucketType) != -1 && item.character.classType != targetCharacter.classType )) {
+							    || ( DestinyArmorPieces.indexOf(item.bucketType) != -1 && item.character.classType != targetCharacter.classType )) {
 								return {
 									description: item.description + " will not be moved"
 								}


### PR DESCRIPTION
If the loadout contains armour and the class of the armour to be
transferred doesn't match the class of the target character, do not
move it.