### PR TITLE
Add setting status bar to Black Opaque

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -1221,7 +1221,7 @@ var app = new (function() {
 				StatusBar.overlaysWebView(false);
 		    }
 			if (typeof StatusBar !== "undefined"){		
-			    StatusBar.styleLightContent();
+			    StatusBar.styleBlackOpaque();
 			    StatusBar.backgroundColorByHexString("#000");
 			}
 		}


### PR DESCRIPTION
The documentation lists all the style settings as light text for dark
backgrounds. Black Opaque seems to be the real one.