### PR TITLE
Hide DestinyDB tooltip when move tooltip is opened

### DIFF
--- a/www/js/app.js
+++ b/www/js/app.js
@@ -5,30 +5,30 @@ window.supportsCloudSaves = window.isChrome || window.isMobile;
 
 var dialog = (function(options){
 	var self = this;
-	
+
 	this.modal;
-	
+
 	this.title = function(title){
 		self.modal = new BootstrapDialog(options);
         self.modal.setTitle(title);
 		return self;
 	}
-	
+
 	this.content = function(content){
 		self.modal.setMessage(content);
 		return self;
 	}
-	
+
 	this.buttons = function(buttons){
 		self.modal.setClosable(true).enableButtons(true).setData("buttons", buttons);
 		return self;
 	}
-	
+
 	this.show = function(cb){
 		self.modal.open();
 		return self;
 	}
-	
+
 	return self.modal;
 });
 
@@ -44,8 +44,8 @@ var Profile = function(model){
 	_.each(model, function(value, key){
 		self[key] = value;
 	});
-	
-	this.icon = ko.observable(self.icon);	
+
+	this.icon = ko.observable(self.icon);
 	this.background = ko.observable(self.background);
 	this.items = ko.observableArray([]);
 	this.uniqueName = self.level + " " + self.race + " " + self.gender + " " + self.classType;
@@ -63,7 +63,7 @@ Profile.prototype = {
 			if (DestinyWeaponPieces.indexOf(item.bucketType) > -1 )
 				return item;
 		});
-	},	
+	},
 	_armor: function(){
 		return _.filter(this.items(), function(item){
 			if (DestinyArmorPieces.indexOf(item.bucketType) > -1 )
@@ -108,7 +108,7 @@ var Item = function(model, profile){
 				//rules for how subclasses can be equipped
 			  var equippableSubclass = (self.bucketType == "Subclasses" && !self.isEquipped() && self.character.id == avatarId) || self.bucketType !== "Subclasses";
 				//if it's in this character and it's equippable
-			 return (!self.isEquipped() && avatarId !== 'Vault' && self.bucketType != 'Materials' && self.bucketType != 'Consumables' && self.description.indexOf("Engram") == -1 && equippableSubclass) || 
+			 return (!self.isEquipped() && avatarId !== 'Vault' && self.bucketType != 'Materials' && self.bucketType != 'Consumables' && self.description.indexOf("Engram") == -1 && equippableSubclass) ||
 			 	//if it's in another character and it's equippable
 			 	(self.characterId != avatarId && avatarId !== 'Vault' && self.bucketType != 'Materials' && self.bucketType != 'Consumables' && self.description.indexOf("Engram") == -1 && equippableSubclass);
 		});
@@ -158,7 +158,7 @@ Item.prototype = {
 	},
 	_isVisible: function(){
 		var $parent = app, self = this;
-		var searchFilter = $parent.searchKeyword() == '' || self.hasPerkSearch($parent.searchKeyword()) || 
+		var searchFilter = $parent.searchKeyword() == '' || self.hasPerkSearch($parent.searchKeyword()) ||
 			($parent.searchKeyword() !== "" && self.description.toLowerCase().indexOf($parent.searchKeyword().toLowerCase()) >-1);
 		var dmgFilter = $parent.dmgFilter().length ==0 || $parent.dmgFilter().indexOf(self.damageTypeName) > -1;
 		var setFilter = $parent.setFilter().length == 0 || $parent.setFilter().indexOf(self.id) > -1 || $parent.setFilterFix().indexOf(self.id) > -1;
@@ -191,7 +191,7 @@ Item.prototype = {
 				return item.tierType != 6;
 			});
 			if ( otherItems.length > 0){
-				var tryNextItem = function(){			
+				var tryNextItem = function(){
 					var item = otherItems[++itemIndex];
 					//console.log(item.description);
 					/* still haven't found a match */
@@ -202,7 +202,7 @@ Item.prototype = {
 								//console.log( item.description + " result was " + isEquipped);
 								if (isEquipped == true){ otherEquipped = true; callback(); }
 								else { tryNextItem(); /*console.log("tryNextItem")*/ }
-							});				
+							});
 						}
 						else {
 							tryNextItem()
@@ -211,7 +211,7 @@ Item.prototype = {
 					}
 				}
 				//console.log("tryNextItem")
-				tryNextItem();			
+				tryNextItem();
 			}
 			else {
 				callback(false);
@@ -233,7 +233,7 @@ Item.prototype = {
 					self.isEquipped(true);
 					self.character.items().forEach(function(item){
 						if (item != self && item.bucketType == self.bucketType){
-							item.isEquipped(false);							
+							item.isEquipped(false);
 						}
 					});
 					if (self.bucketType == "Emblem"){
@@ -248,10 +248,10 @@ Item.prototype = {
 					if (callback) callback(false);
 					else BootstrapDialog.alert(result.Message);
 				}
-			});		
+			});
 		}
 		//console.log("equip called");
-		var sourceCharacterId = self.characterId;		
+		var sourceCharacterId = self.characterId;
 		if (targetCharacterId == sourceCharacterId){
 			//console.log("item is already in the character");
 			/* if item is exotic */
@@ -260,7 +260,7 @@ Item.prototype = {
 				var otherExoticFound = false,
 					otherBucketTypes = DestinyWeaponPieces.indexOf(self.bucketType) > -1 ? _.clone(DestinyWeaponPieces) :  _.clone(DestinyArmorPieces);
 				otherBucketTypes.splice(DestinyWeaponPieces.indexOf(self.bucketType),1);
-				//console.log("the other bucket types are " + JSON.stringify(otherBucketTypes));	
+				//console.log("the other bucket types are " + JSON.stringify(otherBucketTypes));
 				_.each(otherBucketTypes, function(bucketType){
 					var otherExotic = _.filter(_.where( self.character.items(), { bucketType: bucketType, tierType: 6 }), function(item){
 						return item.isEquipped();
@@ -270,7 +270,7 @@ Item.prototype = {
 						//console.log("found another exotic equipped " + otherExotic[0].description);
 						otherExoticFound = true;
 						otherExotic[0].unequip(done);
-					}					
+					}
 				});
 				if (otherExoticFound == false){
 					done();
@@ -279,7 +279,7 @@ Item.prototype = {
 			else {
 				//console.log("item is not exotic");
 				done()
-			}			
+			}
 		}
 		else {
 			//console.log("item is NOT already in the character");
@@ -291,7 +291,7 @@ Item.prototype = {
 			});
 		}
 	},
-	transfer: function(sourceCharacterId, targetCharacterId, amount, cb){		
+	transfer: function(sourceCharacterId, targetCharacterId, amount, cb){
 		//console.log("Item.transfer");
 		//console.log(arguments);
 		//setTimeout(function(){
@@ -348,7 +348,7 @@ Item.prototype = {
 				else {
 					BootstrapDialog.alert(result.Message);
 				}
-			});		
+			});
 		//}, 1000);
 	},
 	store: function(targetCharacterId, callback){
@@ -356,7 +356,7 @@ Item.prototype = {
 		//console.log(arguments);
 		var self = this;
 		var sourceCharacterId = self.characterId, transferAmount = 1;
-		var done = function(){			
+		var done = function(){
 			if (targetCharacterId == "Vault"){
 				//console.log("from character to vault");
 				self.unequip(function(){
@@ -377,23 +377,23 @@ Item.prototype = {
 							//console.log("xfered item to vault");
 							self.transfer("Vault", targetCharacterId, transferAmount, callback);
 						});
-					}					
+					}
 				});
 			}
 			else {
 				//console.log("from vault to character");
 				self.transfer("Vault", targetCharacterId, transferAmount, callback);
-			}		
+			}
 		}
 		if (self.bucketType == "Materials" || self.bucketType == "Consumables"){
 			if (self.primaryStat == 1){
 				done();
 			}
 			else if (app.autoTransferStacks() == true){
-				transferAmount = self.primaryStat; 
+				transferAmount = self.primaryStat;
 				done();
 			}
-			else {				
+			else {
 				var dialogItself = (new dialog({
 		            message: "<div>Transfer Amount: <input type='text' id='materialsAmount' value='" + self.primaryStat + "'></div>",
 		            buttons: [
@@ -403,9 +403,9 @@ Item.prototype = {
 							action: function(){
 								finishTransfer()
 							}
-		            	}, 
+		            	},
 						{
-			                label: 'Close',		                
+			                label: 'Close',
 			                action: function(dialogItself){
 			                    dialogItself.close();
 			                }
@@ -417,7 +417,7 @@ Item.prototype = {
 					if (!isNaN(transferAmount)){ done(); dialogItself.modal.close(); }
 					else { BootstrapDialog.alert("Invalid amount entered: " + transferAmount); }
 				}
-				setTimeout(function(){ $("#materialsAmount").select().bind("keyup", function(e){ if(e.keyCode == 13) { finishTransfer() } }) }, 500);	
+				setTimeout(function(){ $("#materialsAmount").select().bind("keyup", function(e){ if(e.keyCode == 13) { finishTransfer() } }) }, 500);
 			}
 		}
 		else {
@@ -457,9 +457,10 @@ var moveItemPositionHandler = function(element, item){
 			if (element	== activeElement){
 				$movePopup.hide();
 				activeElement = null;
-			}	
+			}
 			else {
 				activeElement = element;
+				$ZamTooltips.hide();
 				if (window.isMobile){
 					$("body").css("padding-bottom","80px");
 					/* removing the delay and adding padding-bottom need to retest issue #12 (bottom row item) */
@@ -478,13 +479,13 @@ var moveItemPositionHandler = function(element, item){
 								if (box + pos.left > ui.element.width){
 									pos.left = pos.left - box;
 								}
-								obj.css(pos);	
+								obj.css(pos);
 							},10);
-						}	
+						}
 					});
 				}
 			}
-		}	
+		}
 	}
 }
 
@@ -502,7 +503,7 @@ window.ko.bindingHandlers.scrollToView = {
 				}
 			})
 			.on("press",function(){
-				
+
 				BootstrapDialog.alert("This icon is " + viewModel.uniqueName);
 			});
 		app.quickIconHighlighter();
@@ -517,7 +518,7 @@ window.ko.bindingHandlers.fastclick = {
 };
 
 ko.bindingHandlers.moveItem = {
-    init: function(element, valueAccessor, allBindings, viewModel, bindingContext) {	
+    init: function(element, valueAccessor, allBindings, viewModel, bindingContext) {
 		Hammer(element, { time: 2000 })
 			.on("tap", moveItemPositionHandler(element, viewModel))
 			/* press is actually hold */
@@ -539,7 +540,7 @@ targetItem: item,
 swapItem: swapItem,
 description: item.description + "'s swap item is " + swapItem.description
 */
-var swapTemplate = _.template('<ul class="list-group">' +	
+var swapTemplate = _.template('<ul class="list-group">' +
 	'<% swapArray.forEach(function(pair){ %>' +
 		'<li class="list-group-item">' +
 			'<div class="row">' +
@@ -547,12 +548,12 @@ var swapTemplate = _.template('<ul class="list-group">' +
 					'<%= pair.description %>' +
 				'</div>' +
 				'<div class="col-lg-3">' +
-					'<a class="item" href="<%= pair.targetItem.href %>" id="<%= pair.targetItem._id %>">' + 
+					'<a class="item" href="<%= pair.targetItem.href %>" id="<%= pair.targetItem._id %>">' +
 						'<img class="itemImage" src="<%= pair.targetItem.icon %>">' +
 					'</a>' +
 				'</div>' +
 				'<div class="col-lg-3">' +
-					'<a class="item" href="<%= pair.swapItem && pair.swapItem.href %>" id="<%= pair.swapItem && pair.swapItem._id %>">' + 
+					'<a class="item" href="<%= pair.swapItem && pair.swapItem.href %>" id="<%= pair.swapItem && pair.swapItem._id %>">' +
 						'<img class="itemImage" src="<%= pair.swapItem && pair.swapItem.icon %>">' +
 					'</a>' +
 				'</div>' +
@@ -578,7 +579,7 @@ var User = function(model){
 	var self = this;
 	_.each(model, function(value, key){
 		self[key] = value;
-	});	
+	});
 	//try loading the Playstation account first
 	this.activeSystem = ko.observable(self.psnId ? "PSN" : "XBL" );
 }
@@ -605,7 +606,7 @@ var app = new (function() {
 		autoTransferStacks: false,
 		padBucketHeight: false
 	};
-	
+
 	var getValue = function(key){
 		var saved = "";
 		if (window.localStorage && window.localStorage.getItem)
@@ -617,7 +618,7 @@ var app = new (function() {
 			return saved
 		}
 	}
-		
+
 	var StoreObj = function(key, compare, writeCallback){
 		var value = ko.observable(compare ? getValue(key) == compare : getValue(key));
 		this.read = function(){
@@ -629,7 +630,7 @@ var app = new (function() {
 			if (writeCallback) writeCallback(newValue);
 		}
 	}
-	
+
 	this.retryCount = ko.observable(0);
 	this.loadingUser = ko.observable(false);
 	this.loadoutMode = ko.observable(false);
@@ -653,10 +654,10 @@ var app = new (function() {
 	this.shareUrl  = ko.observable(defaults.shareUrl);
 	this.showMissing =  ko.observable(defaults.showMissing);
 	this.showUniques =  ko.observable(defaults.showUniques);
-	
+
 	this.activeItem = ko.observable();
 	this.activeUser = ko.observable(new User());
-	
+
 	this.weaponTypes = ko.observableArray();
 	this.characters = ko.observableArray();
 	this.orderedCharacters = ko.computed(function(){
@@ -665,22 +666,22 @@ var app = new (function() {
 		});
 	});
 	this.createLoadout = function(){
-		self.loadoutMode(true);		
+		self.loadoutMode(true);
 		self.activeLoadout(new Loadout());
 	}
 	this.cancelLoadout = function(){
 		self.loadoutMode(false);
 		self.activeLoadout(new Loadout());
-	}	
-	
+	}
+
 	this.showHelp = function(){
 		(new dialog).title("Help").content($("#help").html()).show();
 	}
-		
+
 	this.showAbout = function(){
 		(new dialog).title("About").content($("#about").html()).show();
 	}
-	
+
 	this.clearFilters = function(model, element){
 		self.activeView(defaults.activeView);
 		self.searchKeyword(defaults.searchKeyword);
@@ -705,7 +706,7 @@ var app = new (function() {
 		self.characters().forEach(function(character){
 		  ['weapons','armor'].forEach(function(list){
 	          var item = _.findWhere( character[list](), { '_id': instanceId });
-			  if (item) activeItem = item;			  	
+			  if (item) activeItem = item;
 	      });
 	   	});
 		if (activeItem){
@@ -726,11 +727,11 @@ var app = new (function() {
 			var stats = $content.find(".destt-stat");
 			if (activeItem.stats && stats.length > 0){
 				stats.html(
-					stats.find(".stat-bar").map(function(index, stat){ 
+					stats.find(".stat-bar").map(function(index, stat){
 						var $stat = $("<div>"+stat.outerHTML+"</div>"),
 							label = $stat.find(".stat-bar-label"),
 							labelText = $.trim(label.text());
-						if (labelText in activeItem.stats){							 
+						if (labelText in activeItem.stats){
 							label.text(labelText + ": " + activeItem.stats[labelText]);
 							$stat.find(".stat-bar-static-value").text(" Min/Max: " + $stat.find(".stat-bar-static-value").text());
 						}
@@ -759,17 +760,17 @@ var app = new (function() {
 		self.doRefresh(!self.doRefresh());
 	}
 	this.togglePadBucketHeight = function(){
-		self.toggleBootstrapMenu();		
+		self.toggleBootstrapMenu();
 		self.padBucketHeight(!self.padBucketHeight());
 		self.bucketSizeHandler();
 	}
 	this.toggleTransferStacks = function(){
 		self.toggleBootstrapMenu();
-		self.autoTransferStacks(!self.autoTransferStacks());	
+		self.autoTransferStacks(!self.autoTransferStacks());
 	}
 	this.toggleDestinyDbMode = function(){
 		self.toggleBootstrapMenu();
-		self.destinyDbMode(!self.destinyDbMode());	
+		self.destinyDbMode(!self.destinyDbMode());
 	}
 	this.toggleDestinyDbTooltips = function(){
 		self.toggleBootstrapMenu();
@@ -796,7 +797,7 @@ var app = new (function() {
 	this.setView = function(model, event){
 		self.toggleBootstrapMenu();
 		self.activeView($(event.target).parent().attr("value"));
-	}	
+	}
 	this.setDmgFilter = function(model, event){
 		self.toggleBootstrapMenu();
 		var dmgType = $(event.target).parents('li:first').attr("value");
@@ -813,7 +814,7 @@ var app = new (function() {
 	this.setProgressFilter = function(model, event){
 		self.toggleBootstrapMenu();
 		self.progressFilter($(event.target).parent().attr("value"));
-	}	
+	}
 	this.missingSets = ko.computed(function(){
 		var missingIds = [];
 		self.setFilter().concat(self.setFilterFix()).forEach(function(item){
@@ -827,15 +828,15 @@ var app = new (function() {
 		});
 		return missingIds;
 	})
-						
-	var processItem = function(profile){	
+
+	var processItem = function(profile){
 		return function(item){
 			if (!(item.itemHash in window._itemDefs)){
 				console.log("found an item without a definition! " + JSON.stringify(item));
 				console.log(item.itemHash);
 				return;
 			}
-			var itemObject = { 
+			var itemObject = {
 				id: item.itemHash,
 				_id: item.itemInstanceId,
 				characterId: profile.id,
@@ -845,18 +846,18 @@ var app = new (function() {
 				isGridComplete: item.isGridComplete,
 				locked: item.locked
 			};
-			
+
 			if (item.primaryStat){
 				itemObject.primaryStat = item.primaryStat.value;
-			}	
+			}
 			if (item.progression){
 				itemObject.progression = (item.progression.progressToNextLevel == 0 && item.progression.currentProgress > 0);
 			}
-			
+
 			var info = window._itemDefs[item.itemHash];
 			if (info.bucketTypeHash in DestinyBucketTypes){
-				itemObject = _.extend(itemObject,{ 		
-					description: info.itemName, 
+				itemObject = _.extend(itemObject,{
+					description: info.itemName,
 					bucketType: (item.location == 4) ? "Post Master" : DestinyBucketTypes[info.bucketTypeHash],
 					type: info.itemSubType, //12 (Sniper)
 					typeName: info.itemTypeName, //Sniper Rifle
@@ -876,9 +877,9 @@ var app = new (function() {
 						}
 						else {
 							return perk;
-						}					
+						}
 					});
-					/*if (info.talentGridHash in window._talentGridDefs){					
+					/*if (info.talentGridHash in window._talentGridDefs){
 						itemObject.isUnique = info.tierType != 6 && (_.pluck(_.where(window._talentGridDefs[info.talentGridHash].nodes,{column:5}),'isRandom').indexOf(true) > -1);
 					}
 					else {
@@ -886,14 +887,14 @@ var app = new (function() {
 					}*/
 					itemObject.isUnique = false;
 				}
-			
+
 				if (itemObject.typeName && itemObject.typeName == "Emblem"){
 					itemObject.backgroundPath = self.makeBackgroundUrl(info.secondaryIcon);
 				}
 				if (itemObject.bucketType == "Materials" || itemObject.bucketType == "Consumables"){
 					itemObject.primaryStat = item.stackSize;
 				}
-				if ( info.itemType == 2 && itemObject.bucketType != "Class Items" ){					
+				if ( info.itemType == 2 && itemObject.bucketType != "Class Items" ){
 					itemObject.stats = {};
 					_.each(item.stats, function(stat){
 						if (stat.statHash in window._statDefs){
@@ -907,7 +908,7 @@ var app = new (function() {
 			}
 		}
 	}
-	
+
 	this.addWeaponTypes = function(weapons){
 		weapons.forEach(function(item){
 			if (item.type > 0 && _.where(self.weaponTypes(), { type: item.type }).length == 0){
@@ -915,29 +916,29 @@ var app = new (function() {
 			}
 		});
 	}
-	
+
 	this.makeBackgroundUrl = function(path, excludeDomain){
 		return "url(" + (excludeDomain ? "" : self.bungie.getUrl()) + path + ")";
 	}
-	
+
 	this.hasBothAccounts = function(){
 		return !_.isEmpty(self.activeUser().psnId) && !_.isEmpty(self.activeUser().gamerTag);
 	}
-	
+
 	this.useXboxAccount = function(){
 		self.activeUser().activeSystem("XBL");
 		self.characters.removeAll();
 		self.loadingUser(true);
 		self.search();
 	}
-	
+
 	this.usePlaystationAccount = function(){
 		self.activeUser().activeSystem("PSN");
 		self.characters.removeAll();
 		self.loadingUser(true);
 		self.search();
-	}	
-	
+	}
+
 	this.search = function(){
 		var total = 0, count = 0;
 		/* TODO: implement a better loading bar by using the counts and this: #loadingBar */
@@ -951,7 +952,7 @@ var app = new (function() {
 				setTimeout(self.bucketSizeHandler, 500);
 				//console.log("total time " + (new Date()-t));
 			}
-		}	
+		}
 		self.bungie.search(self.activeUser().activeSystem(),function(e){
 			if (e.error){
 				/* if the first account fails retry the next one*/
@@ -961,7 +962,7 @@ var app = new (function() {
 				}
 				else {
 					BootstrapDialog.alert("Account has no data");
-				}				
+				}
 				self.loadingUser(false);
 				return
 			}
@@ -970,18 +971,18 @@ var app = new (function() {
 			total = avatars.length + 1;
 			self.bungie.vault(function(results){
 				var buckets = results.data.buckets;
-				var profile = new Profile({ 
-					race: "", 
-					order: 0, 
+				var profile = new Profile({
+					race: "",
+					order: 0,
 					gender: "Tower",
-					classType: "Vault", 
-					id: "Vault", 
+					classType: "Vault",
+					id: "Vault",
 					level: "",
 					imgIcon: "assets/vault_icon.jpg",
-					icon: self.makeBackgroundUrl("assets/vault_icon.jpg",true), 
-					background: self.makeBackgroundUrl("assets/vault_emblem.jpg",true) 
+					icon: self.makeBackgroundUrl("assets/vault_icon.jpg",true),
+					background: self.makeBackgroundUrl("assets/vault_emblem.jpg",true)
 				});
-				
+
 				buckets.forEach(function(bucket){
 					bucket.items.forEach(processItem(profile));
 				});
@@ -1005,8 +1006,8 @@ var app = new (function() {
 						race: window._raceDefs[character.characterBase.raceHash].raceName
 					});
 					//console.log("new Profile time " + (new Date()-t));
-					var items = [];						
-					
+					var items = [];
+
 					Object.keys(response.data.buckets).forEach(function(bucket){
 						response.data.buckets[bucket].forEach(function(obj){
 							obj.items.forEach(function(item){
@@ -1014,10 +1015,10 @@ var app = new (function() {
 							});
 						});
 					});
-					
-					//simulate me having the 4th horseman 
+
+					//simulate me having the 4th horseman
 					//items.push({"itemHash":2344494718,"bindStatus":0,"isEquipped":false,"itemInstanceId":"6917529046313340492","itemLevel":22,"stackSize":1,"qualityLevel":70});
-					
+
 					items.forEach(processItem(profile));
 					self.addWeaponTypes(profile.items());
 					self.characters.push(profile);
@@ -1025,14 +1026,14 @@ var app = new (function() {
 					done();
 				});
 			});
-		});		
+		});
 	}
-	
+
 	this.loadData = function(ref){
 		if (self.loadingUser() == false){
 			window.t = (new Date());
 			self.loadingUser(true);
-			self.bungie = new bungie(self.bungie_cookies); 
+			self.bungie = new bungie(self.bungie_cookies);
 			self.characters.removeAll();
 			self.bungie.user(function(user){
 				//console.log("user time " + (new Date()-t));
@@ -1049,23 +1050,23 @@ var app = new (function() {
 					//fix for issue #3?
 					ref = null;
 				}
-				_.defer(function(){					
+				_.defer(function(){
 					self.search();
 				});
-			});			
+			});
 		}
 	}
-	
+
 	this.toggleBootstrapMenu = function(){
-		if ($(".navbar-toggle").is(":visible")) 
+		if ($(".navbar-toggle").is(":visible"))
 			$(".navbar-toggle").click();
 	}
-	
+
 	this.refreshButton = function(){
 		self.toggleBootstrapMenu();
 		self.loadData();
 	}
-	
+
 	this.refreshHandler = function(){
 		clearInterval(self.refreshInterval);
 		if (self.loadoutMode() == true){
@@ -1079,15 +1080,15 @@ var app = new (function() {
 			self.refreshInterval = setInterval(function(){ self.loadData() }, self.refreshSeconds() * 1000);
 		}
 	}
-	
+
 	this.bucketSizeHandler = function(){
 		var buckets = $(".profile:gt(0) .itemBucket").css("height", "auto");
-		if ( self.padBucketHeight() == true ){		
+		if ( self.padBucketHeight() == true ){
 			var maxHeight = ($(".bucket-item:visible:eq(0)").height() + 2) * 3;
-			buckets.css("min-height", maxHeight);			
+			buckets.css("min-height", maxHeight);
 		}
 	}
-	
+
 	this.quickIconHighlighter = function(){
 		var scrollTop = $(window).scrollTop();
 		$(".profile").each(function(index, item){
@@ -1098,11 +1099,11 @@ var app = new (function() {
 		   $quickIcon.css("border", (scrollTop >= top && scrollTop <= bottom) ? "3px solid white" : "none");
 		});
 	}
-	
+
 	this.donate = function(){
 		window.open("http://bit.ly/1Jmb4wQ","_blank");
 	}
-	
+
 	this.readBungieCookie = function(ref, loop){
 		ref.executeScript({
 			code: 'document.cookie'
@@ -1112,20 +1113,20 @@ var app = new (function() {
 				window.localStorage.setItem("bungie_cookies", result);
 				self.loadData(ref, loop);
 			}
-		});	
+		});
 	}
-	
+
 	this.openBungieWindow = function(type){
 		return function(){
 			var loop;
-			window.ref = window.open('https://www.bungie.net/en/User/SignIn/' + type + "?bru=%252Fen%252FUser%252FProfile", '_blank', 'location=yes');			
+			window.ref = window.open('https://www.bungie.net/en/User/SignIn/' + type + "?bru=%252Fen%252FUser%252FProfile", '_blank', 'location=yes');
 			if (isMobile){
 				ref.addEventListener('loadstop', function(event) {
 					ref.executeScript({
 						code: 'document.location.href'
 					}, function(result) {
 						self.readBungieCookie(ref, loop);
-					});					
+					});
 				});
 				ref.addEventListener('exit', function() {
 					if (self.loadingUser() == false){
@@ -1149,14 +1150,14 @@ var app = new (function() {
 			}
 		}
 	}
-	
+
 	this.shiftArrayLeft = function(){
 		self.characters.unshift( self.characters.splice(self.characters().length-1,1)[0] );
 	}
 	this.shiftArrayRight = function(){
 		self.characters(self.characters().concat( self.characters.splice(0,1) ));
 	}
-	
+
 	this.yqlRequest = function(params, callback){
 		var request = window.encodeURIComponent("http://www.towerghostfordestiny.com/api.cfm?" + $.param(params))
 		var requestURL = "https://query.yahooapis.com/v1/public/yql?q=select%20*%20from%20json%20where%20url%3D%22" + request + "%22&format=json&callback=";
@@ -1167,7 +1168,7 @@ var app = new (function() {
 			}
 		});
 	}
-	
+
 	this.saveLoadouts = function(includeMessage){
 		var _includeMessage = _.isUndefined(includeMessage) ? true : includeMessage;
 		if (supportsCloudSaves == true){
@@ -1198,7 +1199,7 @@ var app = new (function() {
 		}
 		else {
 			_loadouts = [];
-		}		
+		}
 		if (supportsCloudSaves == true){
 			self.yqlRequest({ action: "load", membershipId: parseFloat(self.activeUser().user.membershipId) }, function(results){
 				var _results = [];
@@ -1215,7 +1216,7 @@ var app = new (function() {
 				if(_loadouts.length > 0){
 					_results = _loadouts.concat(_results);
 					window.localStorage.setItem("loadouts", "");
-				}	
+				}
 				self.loadouts(_results);
 				/* one time migrate saves the new joined array to the cloud */
 				if(_loadouts.length > 0){
@@ -1230,7 +1231,7 @@ var app = new (function() {
 	this.init = function(){
 		self.doRefresh.subscribe(self.refreshHandler);
 		self.refreshSeconds.subscribe(self.refreshHandler);
-		self.loadoutMode.subscribe(self.refreshHandler);		
+		self.loadoutMode.subscribe(self.refreshHandler);
 		self.bungie_cookies = "";
 		if (window.localStorage && window.localStorage.getItem){
 			self.bungie_cookies = window.localStorage.getItem("bungie_cookies");
@@ -1256,7 +1257,7 @@ var app = new (function() {
 		    if (window.device && device.platform === "iOS" && device.version >= 7.0) {
 				StatusBar.overlaysWebView(false);
 		    }
-			if (typeof StatusBar !== "undefined"){		
+			if (typeof StatusBar !== "undefined"){
 			    StatusBar.styleBlackOpaque();
 			    StatusBar.backgroundColorByHexString("#000");
 			}
@@ -1265,9 +1266,9 @@ var app = new (function() {
 		if (isMobile && isEmptyCookie){
 			self.bungie = new bungie();
 			self.activeUser(new User({"code": 99, "error": "Please sign-in to continue."}));
-		}	
+		}
 		else {
-			setTimeout(function(){ self.loadData() }, isChrome || isMobile ? 1 : 5000);		
+			setTimeout(function(){ self.loadData() }, isChrome || isMobile ? 1 : 5000);
 		}
 		$("form").bind("submit", false);
 		$("html").click(function(e){
@@ -1281,7 +1282,7 @@ var app = new (function() {
 		$(window).scroll(_.throttle(self.quickIconHighlighter, 500));
 		ko.applyBindings(self);
 	}
-}); 
+});
 
 window.zam_tooltips = { addIcons: false, colorLinks: false, renameLinks: false, renderCallback: app.renderCallback, isEnabled: app.tooltipsEnabled() };
 BootstrapDialog.defaultOptions.nl2br = false;
@@ -1289,16 +1290,16 @@ BootstrapDialog.defaultOptions.nl2br = false;
 if (isMobile){
 	window.addEventListener("statusTap", function() {
 	    var target = $("body");
-	 
+
 	    //disable touch scroll to kill existing inertial movement
 	    target.css({
 	        '-webkit-overflow-scrolling' : 'auto',
 	        'overflow-y' : 'hidden'
 	    });
-	 
+
 	    //animate
 	    target.animate({ scrollTop: 0}, 300, "swing", function(){
-	 
+
 	        //re-enable touch scrolling
 	        target.css({
 	            '-webkit-overflow-scrolling' : 'touch',

--- a/www/js/tooltips.min.js
+++ b/www/js/tooltips.min.js
@@ -192,7 +192,7 @@ var $ZamTooltips = new function() {
         div.id = 'zam-tooltip';
         div.setAttribute('style', 'display:none;position:absolute;left:0;top:0;z-index:9999999999');
 		try {
-			
+
 	        document.body.insertBefore(div, document.body.childNodes[0]);
 	        container = div;
 	        ready = true;
@@ -325,9 +325,14 @@ var $ZamTooltips = new function() {
             }
         }
     };
-	
+
 	this.lastElement;
     this.show = function(site, type, id, attach, element) {
+
+        if ($( "#move-popup" ).is(':visible')) {
+            return false;
+        }
+
 		if (element) this.lastElement = element;
         var canonical = getCanonicalName(site, type, id);
         if (type == 'custom') {
@@ -349,7 +354,7 @@ var $ZamTooltips = new function() {
 			container.innerHTML = info.tooltip.replace(/\/\/desimg.zamimg.com/g,'https://desimg.zamimg.com');
 			this.renderCallback(info, container.innerHTML, this.lastElement, function(newContent){
 				container.innerHTML = newContent;
-			});            
+			});
         }
         activeTooltip = canonical;
         attachedTo = attach;
@@ -417,6 +422,7 @@ var $ZamTooltips = new function() {
             site = info.site;
             type = info.type;
             if (activeTooltip == canonical) {
+                console.log('about to show via onTooltip');
                 this.show(info.site, info.type, info.id, attachedTo);
             }
         }
@@ -440,7 +446,7 @@ var $ZamTooltips = new function() {
 		}
     };
     var onMouseout = function(event) {
-		if ($ZamTooltips.enabled() == true){		
+		if ($ZamTooltips.enabled() == true){
 	        lastEvent = event;
 	        $ZamTooltips.hide();
 	        var t = event.target ? event.target : event.srcElement;
@@ -539,6 +545,7 @@ var $ZamTooltips = new function() {
                 attach = t;
             }
             addEvent(t, 'mousemove', onMousemove);
+            console.log('About to show via scan');
             $ZamTooltips.show(match.site, match.type, match.id, attach, t);
             return true;
         } else if (!t.preloaded || basicScan) {


### PR DESCRIPTION
Hide the DestinyDB tooltip when the 'move item' tooltip is opened.

My IDE also stripped a whole bunch of trailing whitespace, making the diff a bit hard to read. My changes are:

 - **[app.js line 463](https://github.com/dasilva333/TowerGhostForDestiny/pull/93/files#diff-bca463ed8ccf5e2058dfe307a95e8501R463)**:  Hide DestinyDB tooltip when move tooltip is opened
 - **[tooltips.min.js line 332](https://github.com/dasilva333/TowerGhostForDestiny/pull/93/files#diff-e186536dba408e545ecff0f8c52ab302R331)**: Don't open DestinyDB tooltip when move tooltip is opened.

I'm not totally thrilled that I had to modify `tooltips.min.js` to make this change, but I didnt really see any other way. I would welcome suggestions on a better way to do this.