### PR TITLE
Add Phonegap directories and files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 build\addon-sdk-1.17
 build\node-modules
 build\mobileWorldContent.db
+node_modules
+platforms
+plugins
+tags*


### PR DESCRIPTION
Building locally with Phonegap creates a number of directories that do
not need to be included in version control. Adding them to .gitignore so
that tools like ag will ignore them too.