### PR TITLE
Add method to sort loadouts by name

### DIFF
--- a/www/index.html
+++ b/www/index.html
@@ -190,7 +190,7 @@
 		            <li data-bind="fastclick: createLoadout"><a href="#">Create</a></li>
 					<li data-bind="fastclick: cancelLoadout"><a href="#">Cancel</a></li>
 					<li class="divider"></li>
-					<!-- ko foreach: { data: loadouts, as: 'loadout' } -->
+					<!-- ko foreach: { data: sortedLoadouts, as: 'loadout' } -->
 						<li data-bind="fastclick: setActive"><a data-bind="text: loadout.name" href="#"></a></li>
 		  			<!--/ko  -->
 		          </ul>

--- a/www/js/app.js
+++ b/www/js/app.js
@@ -234,6 +234,12 @@ var app = new (function() {
 	this.showMissing =  ko.observable(tgd.defaults.showMissing);
 	this.showDuplicate = ko.observable(tgd.defaults.showDuplicate);
 
+	this.sortedLoadouts = ko.computed(function() {
+	   return self.loadouts().sort(function (left, right) {
+	       console.log(left);
+		return left.name == right.name ? 0 : (left.name < right.name ? -1 : 1);
+	});});
+
 	this.activeItem = ko.observable();
 	this.activeUser = ko.observable(new User());
 


### PR DESCRIPTION
New method that will return sorted loadouts and display them
alphabetically.

While not a complete solution to #138 it at least provides a consistent start.