### PR TITLE
Add the item description to the title bar of the transfer materials dialog

### DIFF
--- a/www/js/Item.js
+++ b/www/js/Item.js
@@ -440,7 +440,7 @@ Item.prototype = {
                                 dialogItself.close();
                             }
                         }]
-                    })).title("Transfer Materials").show(true),
+                    })).title("Transfer Materials - " + self.description).show(true),
                     finishTransfer = function() {
                         transferAmount = parseInt($("input#materialsAmount").val());
                         if (!isNaN(transferAmount)) {


### PR DESCRIPTION
@M3Rocket asked for the item's name to be put in the dialog title on the Transfer Materials dialog. (https://github.com/dasilva333/TowerGhostForDestiny/issues/177)