### PR TITLE
Change beautify script to CRLF

### DIFF
--- a/build/code_format.js
+++ b/build/code_format.js
@@ -13,7 +13,7 @@ function prettify(filepath) {
     pretty = beautify[file_type](data, {
 		"indent_size": 4,
 		"indent_char": " ",
-		"eol": "\n",
+		"eol": "\r\n",
 		"indent_level": 0,
 		"indent_with_tabs": false,
 		"preserve_newlines": true,


### PR DESCRIPTION
Every time I run the code_format.js script, there are dozens of files that get modified. The only changes shown are LF vs. CRLF and its annoying to have to manually revert all of these each time. The repository seems to be CRLF, so lets have the beautify script enforce CRLF line endings?