### PR TITLE
fix for issue #487 (Tooltips sometimes too large)

### DIFF
--- a/www/js/tooltips.min.js
+++ b/www/js/tooltips.min.js
@@ -353,8 +353,11 @@ var $ZamTooltips = function() {
             $ZamTooltips.hide();
         };
         var win = getWindowInfo();
-        var w = container.offsetWidth,
-            h = container.offsetHeight;
+        //var w = container.offsetWidth,
+        //    h = container.offsetHeight;
+        var tempcontainer = container.getBoundingClientRect();
+        var w = tempcontainer.width,
+            h = tempcontainer.hight;            
         var pos;
         if (attachedTo) {
             var dim = getElementDimensions(attachedTo);


### PR DESCRIPTION
div size after CSS3 transformation