### PR TITLE
Remove padding from .character-box's .emblem

### DIFF
--- a/www/css/tgd/character-box.css
+++ b/www/css/tgd/character-box.css
@@ -48,6 +48,7 @@
     height: 39px;
     background-color: rgba(0, 0, 0, .2);
     background-size: cover;
+    padding: 0;
 }
 .emblem.active {
 	border: 1px solid rgb(245, 220, 86);


### PR DESCRIPTION
The padding is, presumably unintentionally, applied from `.btn-sm`. Fixes distortion in emblem image

| Before | After |
| --- | --- |
| ![](https://puu.sh/rix7k/519bd5e342.png) | ![](https://puu.sh/rix7L/31cb87006b.png) |
