### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ To get started, check out <http://towerghostfordestiny.com//>! You can look up p
 - [Contributing](#contributing)
 - [Project Powered](#project-powered-by)
 
-##Store Install Links
+## Store Install Links
 
 - [Tower Ghost in Chrome Store](https://chrome.google.com/webstore/detail/tower-ghost-for-destiny/gdjndlpockopgjbonnfdmkcmkcikjhge)
 - [Tower Ghost in Firefox Store](https://addons.mozilla.org/en-us/firefox/addon/tower-ghost-for-destiny/)
@@ -19,19 +19,19 @@ To get started, check out <http://towerghostfordestiny.com//>! You can look up p
 - [Tower Ghost in Google Play Store](https://play.google.com/store/apps/details?id=com.richardpinedo.towerghostfordestiny)
 - [Tower Ghost in Windows Phone Store](http://www.windowsphone.com/en-us/store/app/destiny-item-viewer/f98e5060-3464-419c-b83d-14300714a676)
 
-##Download Files
+## Download Files
 
 You can find the latest download for each platform here:
 
 <http://towerghostfordestiny.com/index.php/downloads/>
 
-##Install Instructions
+## Install Instructions
 
 Latest help & FAQ support found here: 
 
 <http://towerghostfordestiny.com/index.php/support/>
 
-##Editing CSS
+## Editing CSS
 
 - Go to the build directory of the project (`cd build`)
 - First you need to make sure you have Node.js
@@ -44,10 +44,10 @@ Latest help & FAQ support found here:
 
 **NOTE!** If you make changes to the SCSS, you need to run `grunt prod` before you put in your PR, so it has a production build of the SCSS (aka, no source maps)
 
-##Contributing
+## Contributing
 
 Please read through our [contributing guidelines](CONTRIBUTING.md).
 
-##Project Powered By
+## Project Powered By
 
 <img src="http://towerghostfordestiny.com/browserstack.png">

--- a/build/bootswatch/bower_components/html5shiv/readme.md
+++ b/build/bootswatch/bower_components/html5shiv/readme.md
@@ -7,7 +7,7 @@ The HTML5 Shiv enables use of HTML5 sectioning elements in legacy Internet Explo
 #### `html5shiv.js`
 *  This includes the basic `createElement()` shiv technique, along with monkeypatches for `document.createElement` and `document.createDocumentFragment` for IE6-8. It also applies [basic styling](https://github.com/aFarkas/html5shiv/blob/51da98dabd3c537891b7fe6114633fb10de52473/src/html5shiv.js#L216-220) for HTML5 elements for IE6-9, Safari 4.x and FF 3.x.
 
-####`html5shiv-printshiv.js` 
+#### `html5shiv-printshiv.js` 
 *  This includes all of the above, as well as a mechanism allowing HTML5 elements to be styled and contain children while being printed in IE 6-8.
 
 ### Who can I get mad at now?
@@ -20,7 +20,7 @@ For the full story of HTML5 Shiv and all of the people involved in making it, re
 
 ## Installation
 
-###Using [Bower](http://bower.io/)
+### Using [Bower](http://bower.io/)
 
 `bower install html5shiv --save-dev`
 
@@ -34,7 +34,7 @@ Include the HTML5 shiv in the `<head>` of your page in a conditional comment and
 <![endif]-->
 ```
 
-###Manual installation
+### Manual installation
 
 Download and extract the [latest zip package](https://github.com/aFarkas/html5shiv/archive/master.zip) from this repositiory and copy the two files `dist/html5shiv.js` and `dist/html5shiv-printshiv.js` into your project. Then include one of them into your `<head>` as above. 
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
